### PR TITLE
Namespace install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ language: python
 python:
     - "3.5"
     - "3.6"
-    - "3.7-dev"
+    - "3.7"
+    - "3.8-dev"
 install: pip install tox-travis
 script: tox
 after_success:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include README.md
 include requirements.txt
+include sk_dsp_comm/pyaudio_helper/__version__.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 matplotlib
 numpy
 pyaudio
+setuptools>=40.1.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import find_namespace_packages, setup
 import os
 import codecs
 
@@ -32,7 +32,7 @@ setup(name='pyaudio-helper',
       maintainer='Chiranth Siddappa',
       maintainer_email='chiranthsiddappa@gmail.com',
       url='https://github.com/scikit-dsp-comm/pyaudio_helper',
-      packages=['sk_dsp_comm.pyaudio_helper'],
+      packages=find_namespace_packages(include=['scikit_dsp_comm.*']),
       include_package_data=True,
       license='BSD',
       install_requires=requirements.split(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py31,py34,py35,py36,docs
+envlist=py27,py31,py34,py35,py36,py37,py38,docs
 [testenv]
 deps=
     -rrequirements.txt


### PR DESCRIPTION
We will now use `find_namespace_packages` to perform the installation of the package. This requires setuptools>=40.1.0.

No other changes are proposed.